### PR TITLE
allowing geocoder to autogenerate lat/long for listings

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -6,10 +6,7 @@ class Listing < ApplicationRecord
 
   validates :address, presence: true
   validates :name, presence: true
-  validates :longitude, presence: true
-  validates :latitude, presence: true
 
-  include Geocoder::Model::Mongoid
   geocoded_by :address, skip_index: true
   after_validation :geocode, if: :will_save_change_to_address?
   has_one_attached :photo


### PR DESCRIPTION
- geocoder generates lat and long upon creation of listing with valid address. does not require lat and long initially